### PR TITLE
Add a minimal CLI entrypoint and enforce loop budgets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,3 +62,6 @@ Defer unless explicitly requested:
 
 ## Notes for autonomous coding agents
 If an issue references this file, treat it as the default product and architecture brief. Keep changes local, incremental, and well-documented.
+## Repository notes
+- `SpecLoopState.add_draft()` and `.add_critique()` enforce the configured turn budgets via `TurnLimitError`.
+- The CLI entrypoint is `but-dad run --input <json> --output <markdown>`, consuming an explicit `turns` array and rendering a markdown artifact.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,33 @@ source .venv/bin/activate
 pip install -e '.[dev]'
 pytest
 ```
+
+## CLI
+
+Render a markdown spec artifact from a structured turn log:
+
+```bash
+but-dad run --input loop.json --output artifacts/final-spec.md
+```
+
+Example input file:
+
+```json
+{
+  "title": "Release readiness spec",
+  "config": {"max_writer_turns": 2, "max_coach_turns": 2},
+  "turns": [
+    {
+      "role": "writer",
+      "content": "Define the webhook recovery flow.",
+      "rationale": ["Keep the initial scope small."]
+    },
+    {
+      "role": "coach",
+      "claim": "The failure mode is underspecified.",
+      "recommendation": "Document retry boundaries.",
+      "sources": ["https://example.com/retries"]
+    }
+  ]
+}
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ dev = [
   "pytest>=8.0",
 ]
 
+[project.scripts]
+but-dad = "but_dad.cli:main"
+
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 

--- a/src/but_dad/__init__.py
+++ b/src/but_dad/__init__.py
@@ -1,3 +1,3 @@
-from .loop import Critique, LoopConfig, SpecDraft, SpecLoopState
+from .loop import Critique, LoopConfig, SpecDraft, SpecLoopState, TurnLimitError
 
-__all__ = ["Critique", "LoopConfig", "SpecDraft", "SpecLoopState"]
+__all__ = ["Critique", "LoopConfig", "SpecDraft", "SpecLoopState", "TurnLimitError"]

--- a/src/but_dad/__main__.py
+++ b/src/but_dad/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+raise SystemExit(main())

--- a/src/but_dad/cli.py
+++ b/src/but_dad/cli.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+from .loop import LoopConfig, SpecLoopState
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="but-dad", description="Render a bounded writer/coach spec loop artifact.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="Build a spec artifact from a structured turn log.")
+    run_parser.add_argument("--input", required=True, type=Path, help="Path to a JSON file describing the loop turns.")
+    run_parser.add_argument("--output", required=True, type=Path, help="Path for the rendered markdown artifact.")
+    run_parser.add_argument("--title", help="Optional title override for the rendered artifact.")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "run":
+        return run(args.input, args.output, args.title)
+
+    parser.error(f"unsupported command: {args.command}")
+    return 2
+
+
+def run(input_path: Path, output_path: Path, title_override: str | None = None) -> int:
+    payload = json.loads(input_path.read_text())
+    state = _state_from_payload(payload)
+    title = title_override or payload.get("title", "But Dad Spec")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(state.build_final_spec(title=title))
+
+    print(
+        f"Wrote {output_path} "
+        f"(writer turns: {state.writer_turns_used}/{state.config.max_writer_turns}, "
+        f"coach turns: {state.coach_turns_used}/{state.config.max_coach_turns})"
+    )
+    return 0
+
+
+def _state_from_payload(payload: dict[str, Any]) -> SpecLoopState:
+    config_data = payload.get("config", {})
+    state = SpecLoopState(
+        config=LoopConfig(
+            max_writer_turns=config_data.get("max_writer_turns", 6),
+            max_coach_turns=config_data.get("max_coach_turns", 6),
+        )
+    )
+
+    turns = payload.get("turns", [])
+    if not isinstance(turns, list):
+        raise ValueError("turns must be a list")
+
+    for turn in turns:
+        role = turn.get("role")
+        if role == "writer":
+            state.add_draft(turn["content"], rationale=turn.get("rationale"))
+            continue
+        if role == "coach":
+            state.add_critique(
+                turn["claim"],
+                turn["recommendation"],
+                sources=turn.get("sources"),
+            )
+            continue
+        raise ValueError(f"unsupported turn role: {role!r}")
+
+    return state

--- a/src/but_dad/loop.py
+++ b/src/but_dad/loop.py
@@ -4,6 +4,10 @@ from dataclasses import dataclass, field
 from typing import List
 
 
+class TurnLimitError(ValueError):
+    pass
+
+
 @dataclass(slots=True)
 class Critique:
     claim: str
@@ -31,11 +35,13 @@ class SpecLoopState:
     critiques: List[Critique] = field(default_factory=list)
 
     def add_draft(self, content: str, rationale: List[str] | None = None) -> SpecDraft:
+        self._ensure_writer_capacity()
         draft = SpecDraft(version=len(self.drafts) + 1, content=content, rationale=rationale or [])
         self.drafts.append(draft)
         return draft
 
     def add_critique(self, claim: str, recommendation: str, sources: List[str] | None = None) -> Critique:
+        self._ensure_coach_capacity()
         critique = Critique(claim=claim, recommendation=recommendation, sources=sources or [])
         self.critiques.append(critique)
         return critique
@@ -48,8 +54,87 @@ class SpecLoopState:
     def coach_turns_used(self) -> int:
         return len(self.critiques)
 
+    @property
+    def remaining_writer_turns(self) -> int:
+        return self.config.max_writer_turns - self.writer_turns_used
+
+    @property
+    def remaining_coach_turns(self) -> int:
+        return self.config.max_coach_turns - self.coach_turns_used
+
     def can_continue(self) -> bool:
-        return (
-            self.writer_turns_used < self.config.max_writer_turns
-            and self.coach_turns_used < self.config.max_coach_turns
-        )
+        return self.remaining_writer_turns > 0 and self.remaining_coach_turns > 0
+
+    def build_final_spec(self, title: str = "But Dad Spec") -> str:
+        lines = [
+            f"# {title}",
+            "",
+            "## Loop summary",
+            f"- Writer turns: {self.writer_turns_used}/{self.config.max_writer_turns}",
+            f"- Coach turns: {self.coach_turns_used}/{self.config.max_coach_turns}",
+            "",
+            "## Current spec",
+        ]
+
+        if self.drafts:
+            lines.extend([self.drafts[-1].content, ""])
+        else:
+            lines.extend(["_No draft has been recorded yet._", ""])
+
+        lines.extend(["## Draft history", ""])
+        if not self.drafts:
+            lines.extend(["_No drafts recorded._", ""])
+        else:
+            for draft in self.drafts:
+                lines.extend([f"### Draft {draft.version}", "", draft.content, ""])
+                if draft.rationale:
+                    lines.append("#### Rationale")
+                    lines.extend(f"- {item}" for item in draft.rationale)
+                    lines.append("")
+
+        lines.extend(["## Coach critiques", ""])
+        if not self.critiques:
+            lines.extend(["_No critiques recorded._", ""])
+        else:
+            for index, critique in enumerate(self.critiques, start=1):
+                lines.extend(
+                    [
+                        f"### Critique {index}",
+                        "",
+                        f"- Claim: {critique.claim}",
+                        f"- Recommendation: {critique.recommendation}",
+                    ]
+                )
+                if critique.sources:
+                    lines.append("- Sources:")
+                    lines.extend(f"  - {source}" for source in critique.sources)
+                lines.append("")
+
+        lines.extend(["## Source appendix", ""])
+        sources = self._unique_sources()
+        if sources:
+            lines.extend(f"{index}. {source}" for index, source in enumerate(sources, start=1))
+        else:
+            lines.append("_No sources captured._")
+
+        lines.append("")
+        return "\n".join(lines)
+
+    def _ensure_writer_capacity(self) -> None:
+        if self.writer_turns_used >= self.config.max_writer_turns:
+            raise TurnLimitError("writer turn limit reached")
+
+    def _ensure_coach_capacity(self) -> None:
+        if self.coach_turns_used >= self.config.max_coach_turns:
+            raise TurnLimitError("coach turn limit reached")
+
+    def _unique_sources(self) -> List[str]:
+        seen: set[str] = set()
+        ordered_sources: List[str] = []
+        for critique in self.critiques:
+            for source in critique.sources:
+                if source in seen:
+                    continue
+                seen.add(source)
+                ordered_sources.append(source)
+        return ordered_sources

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,4 +1,9 @@
-from but_dad.loop import LoopConfig, SpecLoopState
+import json
+
+import pytest
+
+from but_dad.cli import main
+from but_dad.loop import LoopConfig, SpecLoopState, TurnLimitError
 
 
 def test_loop_respects_default_turn_budget() -> None:
@@ -27,3 +32,77 @@ def test_custom_budget_is_supported() -> None:
 
     state.add_draft("draft 2")
     assert state.can_continue() is False
+
+
+def test_add_draft_and_critique_enforce_turn_limits() -> None:
+    state = SpecLoopState(config=LoopConfig(max_writer_turns=1, max_coach_turns=1))
+
+    state.add_draft("draft 1")
+    state.add_critique("claim 1", "fix 1")
+
+    with pytest.raises(TurnLimitError, match="writer turn limit reached"):
+        state.add_draft("draft 2")
+
+    with pytest.raises(TurnLimitError, match="coach turn limit reached"):
+        state.add_critique("claim 2", "fix 2")
+
+
+def test_build_final_spec_includes_latest_draft_and_unique_sources() -> None:
+    state = SpecLoopState(config=LoopConfig(max_writer_turns=3, max_coach_turns=3))
+    state.add_draft("draft 1", rationale=["start from a minimal brief"])
+    state.add_draft("draft 2")
+    state.add_critique(
+        "missing source appendix",
+        "group citations into a dedicated appendix",
+        sources=["https://example.com/a", "https://example.com/a", "https://example.com/b"],
+    )
+
+    artifact = state.build_final_spec(title="CLI Demo")
+
+    assert "# CLI Demo" in artifact
+    assert "- Writer turns: 2/3" in artifact
+    assert "- Coach turns: 1/3" in artifact
+    assert "## Current spec\ndraft 2" in artifact
+    assert "#### Rationale\n- start from a minimal brief" in artifact
+    assert "1. https://example.com/a" in artifact
+    assert "2. https://example.com/b" in artifact
+
+
+def test_cli_writes_markdown_artifact(tmp_path, capsys: pytest.CaptureFixture[str]) -> None:
+    input_path = tmp_path / "loop.json"
+    output_path = tmp_path / "artifacts" / "final-spec.md"
+    input_path.write_text(
+        json.dumps(
+            {
+                "title": "Release readiness spec",
+                "config": {"max_writer_turns": 2, "max_coach_turns": 2},
+                "turns": [
+                    {
+                        "role": "writer",
+                        "content": "Define the webhook recovery flow.",
+                        "rationale": ["Keep the initial scope small."],
+                    },
+                    {
+                        "role": "coach",
+                        "claim": "The failure mode is underspecified.",
+                        "recommendation": "Document retry boundaries.",
+                        "sources": ["https://example.com/retries"],
+                    },
+                ],
+            }
+        )
+    )
+
+    exit_code = main(["run", "--input", str(input_path), "--output", str(output_path)])
+
+    assert exit_code == 0
+    artifact = output_path.read_text()
+    assert "# Release readiness spec" in artifact
+    assert "Define the webhook recovery flow." in artifact
+    assert "Document retry boundaries." in artifact
+    assert "1. https://example.com/retries" in artifact
+
+    captured = capsys.readouterr()
+    assert f"Wrote {output_path}" in captured.out
+    assert "writer turns: 1/2" in captured.out
+    assert "coach turns: 1/2" in captured.out


### PR DESCRIPTION
## Summary
- add a minimal but-dad run CLI that reads an explicit turn log and renders a markdown spec artifact
- enforce writer/coach turn budgets in SpecLoopState instead of only reporting them
- document the CLI and add tests for budget enforcement and artifact rendering

## Testing
- . .venv/bin/activate && pytest -q
- . .venv/bin/activate && but-dad run --input /tmp/butdad-loop.json --output /tmp/butdad-final.md

Fixes #6
