### PR TITLE
Add minimal fast-agent writer/coach experiment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,3 +62,8 @@ Defer unless explicitly requested:
 
 ## Notes for autonomous coding agents
 If an issue references this file, treat it as the default product and architecture brief. Keep changes local, incremental, and well-documented.
+
+## Repository-specific implementation notes
+- The minimal fast-agent experiment lives in `src/but_dad/fast_agent_experiment.py`.
+- Keep fast-agent integration optional; tests should continue to pass without installing `fast-agent-mcp`.
+- Save reviewable artifacts under `docs/experiments/` rather than hiding findings in transient logs.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@ source .venv/bin/activate
 pip install -e '.[dev]'
 pytest
 ```
+
+## fast-agent experiment
+
+Issue #8 adds a minimal fast-agent writer/coach prototype plus saved findings.
+
+```bash
+python -m but_dad.fast_agent_experiment \
+  --topic "Produce an implementation-ready spec for a webhook-based issue handoff."
+```
+
+This writes:
+
+- `docs/experiments/fast-agent-sample-output.md`
+- `docs/experiments/fast-agent-findings.md`

--- a/docs/experiments/fast-agent-findings.md
+++ b/docs/experiments/fast-agent-findings.md
@@ -1,0 +1,58 @@
+# fast-agent experiment findings
+
+_Generated on 2026-03-31._
+
+## What was added
+
+- `src/but_dad/fast_agent_experiment.py` wires a minimal fast-agent evaluator-optimizer experiment for the But Dad writer/coach loop.
+- `docs/experiments/fast-agent-sample-output.md` stores a deterministic dry-run transcript for review.
+- The live fast-agent path expects the writer to act as the generator and the coach to act as the evaluator.
+
+## Runnable commands
+
+Dry run:
+
+```bash
+python -m but_dad.fast_agent_experiment --topic "Produce an implementation-ready spec for a webhook-based issue handoff." --output docs/experiments/fast-agent-sample-output.md
+```
+
+Live run once fast-agent, model credentials, and MCP server config are available:
+
+```bash
+python -m but_dad.fast_agent_experiment --live --config-path path/to/fastagent.config.yaml --model sonnet --topic "Produce an implementation-ready spec for a webhook-based issue handoff." --output docs/experiments/fast-agent-live-output.md
+```
+
+## Why evaluator-optimizer is the best minimal fit
+
+- It already models a generator/evaluator loop.
+- `max_refinements=5` gives at most 6 writer drafts total.
+- The coach can return a quality rating plus actionable critique on each pass.
+- The final artifact stays inspectable because the loop remains explicit.
+
+## Malachi status
+
+No MALACHI-related environment variables were present and no Malachi-specific fast-agent configuration was checked into the repo, so a live Malachi-backed run could not be verified.
+
+Evidence:
+- Environment inspection found no variable names containing MALACHI.
+- The repo does not ship a fastagent.config.yaml with a Malachi model binding.
+
+This is an inference from local environment inspection on 2026-03-31; it is not proof that Malachi is impossible everywhere.
+
+## Verdict
+
+fast-agent looks like a **good structural fit** for But Dad's loop, but the current environment does **not** prove operational fit yet.
+The missing piece is a live run with a real model plus research-capable MCP servers so the coach can ground critiques in current sources.
+
+## Follow-up work
+
+1. Supply a `fastagent.config.yaml` that defines the search/fetch MCP servers used by the coach.
+2. Retry the live run with Malachi if credentials or a supported model binding become available.
+3. Save one real transcript from the live run and compare the resulting spec quality against the existing loop state approach.
+
+## Reference links
+
+- fast-agent docs: https://fast-agent.ai/
+- fast-agent workflow docs: https://fast-agent.ai/agents/workflows/
+- fast-agent model docs: https://fast-agent.ai/models/
+- fast-agent package: https://pypi.org/project/fast-agent-mcp/

--- a/docs/experiments/fast-agent-sample-output.md
+++ b/docs/experiments/fast-agent-sample-output.md
@@ -1,0 +1,112 @@
+# But Dad fast-agent dry run
+
+Topic: Produce an implementation-ready spec for a webhook-based issue handoff.
+
+This file is a deterministic preview of the writer-versus-coach loop structure.
+It does not claim live web research was executed.
+
+## Writer turn 1
+
+Draft 1 tightens the scope for `Produce an implementation-ready spec for a webhook-based issue handoff.` and converts the latest critique into testable requirements, edge cases, and acceptance criteria.
+
+Rationale:
+- Preserve the single living spec.
+- Turn criticism into concrete edits.
+
+## Coach turn 1
+
+Coach turn 1 says the draft still needs sharper acceptance criteria and clearer handling of failure paths.
+
+Recommendation: Add explicit success/failure examples, call out assumptions, and attach source notes for any research-backed claims.
+
+Sources consulted in a live run would be listed here.
+- https://example.com/research/1
+
+## Writer turn 2
+
+Draft 2 tightens the scope for `Produce an implementation-ready spec for a webhook-based issue handoff.` and converts the latest critique into testable requirements, edge cases, and acceptance criteria.
+
+Rationale:
+- Preserve the single living spec.
+- Turn criticism into concrete edits.
+
+## Coach turn 2
+
+Coach turn 2 says the draft still needs sharper acceptance criteria and clearer handling of failure paths.
+
+Recommendation: Add explicit success/failure examples, call out assumptions, and attach source notes for any research-backed claims.
+
+Sources consulted in a live run would be listed here.
+- https://example.com/research/2
+
+## Writer turn 3
+
+Draft 3 tightens the scope for `Produce an implementation-ready spec for a webhook-based issue handoff.` and converts the latest critique into testable requirements, edge cases, and acceptance criteria.
+
+Rationale:
+- Preserve the single living spec.
+- Turn criticism into concrete edits.
+
+## Coach turn 3
+
+Coach turn 3 says the draft still needs sharper acceptance criteria and clearer handling of failure paths.
+
+Recommendation: Add explicit success/failure examples, call out assumptions, and attach source notes for any research-backed claims.
+
+Sources consulted in a live run would be listed here.
+- https://example.com/research/3
+
+## Writer turn 4
+
+Draft 4 tightens the scope for `Produce an implementation-ready spec for a webhook-based issue handoff.` and converts the latest critique into testable requirements, edge cases, and acceptance criteria.
+
+Rationale:
+- Preserve the single living spec.
+- Turn criticism into concrete edits.
+
+## Coach turn 4
+
+Coach turn 4 says the draft still needs sharper acceptance criteria and clearer handling of failure paths.
+
+Recommendation: Add explicit success/failure examples, call out assumptions, and attach source notes for any research-backed claims.
+
+Sources consulted in a live run would be listed here.
+- https://example.com/research/4
+
+## Writer turn 5
+
+Draft 5 tightens the scope for `Produce an implementation-ready spec for a webhook-based issue handoff.` and converts the latest critique into testable requirements, edge cases, and acceptance criteria.
+
+Rationale:
+- Preserve the single living spec.
+- Turn criticism into concrete edits.
+
+## Coach turn 5
+
+Coach turn 5 says the draft still needs sharper acceptance criteria and clearer handling of failure paths.
+
+Recommendation: Add explicit success/failure examples, call out assumptions, and attach source notes for any research-backed claims.
+
+Sources consulted in a live run would be listed here.
+- https://example.com/research/5
+
+## Writer turn 6
+
+Draft 6 tightens the scope for `Produce an implementation-ready spec for a webhook-based issue handoff.` and converts the latest critique into testable requirements, edge cases, and acceptance criteria.
+
+Rationale:
+- Preserve the single living spec.
+- Turn criticism into concrete edits.
+
+## Coach turn 6
+
+Coach turn 6 says the draft still needs sharper acceptance criteria and clearer handling of failure paths.
+
+Recommendation: Add explicit success/failure examples, call out assumptions, and attach source notes for any research-backed claims.
+
+Sources consulted in a live run would be listed here.
+- https://example.com/research/6
+
+## Fit summary
+
+The evaluator-optimizer loop is structurally close to But Dad: the writer is the generator, the coach is the evaluator, and `max_refinements=5` maps to a six-draft cap.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = []
 dev = [
   "pytest>=8.0",
 ]
+fast-agent = [
+  "fast-agent-mcp>=0.2.49",
+]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/but_dad/fast_agent_experiment.py
+++ b/src/but_dad/fast_agent_experiment.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from textwrap import dedent
+from typing import Sequence
+
+from but_dad.loop import LoopConfig, SpecLoopState
+
+DEFAULT_TOPIC = "Produce an implementation-ready spec for a webhook-based issue handoff."
+DEFAULT_OUTPUT_PATH = Path("docs/experiments/fast-agent-sample-output.md")
+DEFAULT_FINDINGS_PATH = Path("docs/experiments/fast-agent-findings.md")
+DEFAULT_CONFIG_PATH = "path/to/fastagent.config.yaml"
+DEFAULT_LIVE_MODEL = "sonnet"
+
+
+@dataclass(frozen=True, slots=True)
+class MalachiCheck:
+    available: bool
+    summary: str
+    evidence: tuple[str, ...]
+
+
+def build_writer_instruction(config: LoopConfig | None = None) -> str:
+    loop = config or LoopConfig()
+    return dedent(
+        f"""
+        You are the But Dad writer agent.
+        Draft a single living specification that becomes more implementation-ready on every pass.
+        You may revise the same spec up to {loop.max_writer_turns} total writer turns.
+
+        Rules:
+        - Keep requirements explicit, testable, and concrete.
+        - Preserve useful material from earlier drafts instead of restarting.
+        - Convert coach feedback into spec edits, edge cases, and acceptance criteria.
+        - End with a compact changelog describing what changed in this draft.
+        """
+    ).strip()
+
+
+def build_coach_instruction(config: LoopConfig | None = None) -> str:
+    loop = config or LoopConfig()
+    return dedent(
+        f"""
+        You are the But Dad coach agent.
+        Act as the evaluator in a writer-versus-coach loop with at most {loop.max_coach_turns} coach turns.
+
+        Your job:
+        - Nitpick ambiguity, missing edge cases, missing acceptance criteria, and hand-waving.
+        - Use configured web research tools before making major claims whenever the workflow is run live.
+        - Cite the sources you actually used and explain why each one matters.
+        - Rate the draft overall as EXCELLENT, GOOD, FAIR, or POOR.
+        - Provide actionable feedback that the writer can apply in the next revision.
+
+        Respond with sections in this order:
+        1. Overall rating
+        2. Blocking issues
+        3. Recommended edits
+        4. Sources consulted
+        """
+    ).strip()
+
+
+def build_loop_prompt(topic: str, config: LoopConfig | None = None) -> str:
+    loop = config or LoopConfig()
+    return dedent(
+        f"""
+        Topic: {topic}
+
+        Run a bounded writer-versus-coach specification loop.
+        - Maximum writer turns: {loop.max_writer_turns}
+        - Maximum coach turns: {loop.max_coach_turns}
+        - The coach should use web research when live tools are configured.
+
+        Final deliverable requirements:
+        - one implementation-ready spec
+        - explicit acceptance criteria
+        - edge cases and unresolved assumptions
+        - a source appendix
+        - a short fit assessment for whether this fast-agent prototype matches But Dad's needs
+        """
+    ).strip()
+
+
+def build_live_command(topic: str = DEFAULT_TOPIC) -> str:
+    escaped_topic = topic.replace('"', '\\"')
+    return (
+        "python -m but_dad.fast_agent_experiment "
+        f'--live --config-path {DEFAULT_CONFIG_PATH} --model {DEFAULT_LIVE_MODEL} '
+        f'--topic "{escaped_topic}" --output docs/experiments/fast-agent-live-output.md'
+    )
+
+
+def detect_malachi_support(env_var_names: Sequence[str] | None = None) -> MalachiCheck:
+    names = tuple(sorted(env_var_names or os.environ))
+    malachi_names = tuple(name for name in names if "MALACHI" in name.upper())
+
+    if malachi_names:
+        return MalachiCheck(
+            available=True,
+            summary="Malachi-related environment variables were detected.",
+            evidence=malachi_names,
+        )
+
+    return MalachiCheck(
+        available=False,
+        summary=(
+            "No MALACHI-related environment variables were present and no Malachi-specific fast-agent "
+            "configuration was checked into the repo, so a live Malachi-backed run could not be verified."
+        ),
+        evidence=(
+            "Environment inspection found no variable names containing MALACHI.",
+            "The repo does not ship a fastagent.config.yaml with a Malachi model binding.",
+        ),
+    )
+
+
+def build_dry_run_transcript(topic: str, config: LoopConfig | None = None) -> str:
+    loop = config or LoopConfig()
+    state = SpecLoopState(config=loop)
+    lines = [
+        "# But Dad fast-agent dry run",
+        "",
+        f"Topic: {topic}",
+        "",
+        "This file is a deterministic preview of the writer-versus-coach loop structure.",
+        "It does not claim live web research was executed.",
+        "",
+    ]
+
+    while state.can_continue():
+        turn = state.writer_turns_used + 1
+        draft = state.add_draft(
+            content=(
+                f"Draft {turn} tightens the scope for `{topic}` and converts the latest critique "
+                f"into testable requirements, edge cases, and acceptance criteria."
+            ),
+            rationale=[
+                "Preserve the single living spec.",
+                "Turn criticism into concrete edits.",
+            ],
+        )
+        critique = state.add_critique(
+            claim=(
+                f"Coach turn {turn} says the draft still needs sharper acceptance criteria and "
+                "clearer handling of failure paths."
+            ),
+            recommendation=(
+                "Add explicit success/failure examples, call out assumptions, and attach source notes "
+                "for any research-backed claims."
+            ),
+            sources=[
+                f"https://example.com/research/{turn}",
+            ],
+        )
+        lines.extend(
+            [
+                f"## Writer turn {turn}",
+                "",
+                draft.content,
+                "",
+                "Rationale:",
+                *(f"- {item}" for item in draft.rationale),
+                "",
+                f"## Coach turn {turn}",
+                "",
+                critique.claim,
+                "",
+                f"Recommendation: {critique.recommendation}",
+                "",
+                "Sources consulted in a live run would be listed here.",
+                *(f"- {source}" for source in critique.sources),
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "## Fit summary",
+            "",
+            (
+                "The evaluator-optimizer loop is structurally close to But Dad: the writer is the "
+                "generator, the coach is the evaluator, and `max_refinements=5` maps to a six-draft cap."
+            ),
+        ]
+    )
+    return "\n".join(lines).strip() + "\n"
+
+
+def build_findings_markdown(
+    topic: str,
+    malachi_check: MalachiCheck,
+    config: LoopConfig | None = None,
+) -> str:
+    loop = config or LoopConfig()
+    today = date.today().isoformat()
+    evidence_lines = "\n".join(f"- {item}" for item in malachi_check.evidence)
+    return "\n".join(
+        [
+            "# fast-agent experiment findings",
+            "",
+            f"_Generated on {today}._",
+            "",
+            "## What was added",
+            "",
+            "- `src/but_dad/fast_agent_experiment.py` wires a minimal fast-agent evaluator-optimizer experiment for the But Dad writer/coach loop.",
+            "- `docs/experiments/fast-agent-sample-output.md` stores a deterministic dry-run transcript for review.",
+            "- The live fast-agent path expects the writer to act as the generator and the coach to act as the evaluator.",
+            "",
+            "## Runnable commands",
+            "",
+            "Dry run:",
+            "",
+            "```bash",
+            f'python -m but_dad.fast_agent_experiment --topic "{topic}" --output {DEFAULT_OUTPUT_PATH}',
+            "```",
+            "",
+            "Live run once fast-agent, model credentials, and MCP server config are available:",
+            "",
+            "```bash",
+            build_live_command(topic),
+            "```",
+            "",
+            "## Why evaluator-optimizer is the best minimal fit",
+            "",
+            "- It already models a generator/evaluator loop.",
+            f"- `max_refinements=5` gives at most {loop.max_writer_turns} writer drafts total.",
+            "- The coach can return a quality rating plus actionable critique on each pass.",
+            "- The final artifact stays inspectable because the loop remains explicit.",
+            "",
+            "## Malachi status",
+            "",
+            malachi_check.summary,
+            "",
+            "Evidence:",
+            evidence_lines,
+            "",
+            (
+                f"This is an inference from local environment inspection on {today}; "
+                "it is not proof that Malachi is impossible everywhere."
+            ),
+            "",
+            "## Verdict",
+            "",
+            (
+                "fast-agent looks like a **good structural fit** for But Dad's loop, "
+                "but the current environment does **not** prove operational fit yet."
+            ),
+            (
+                "The missing piece is a live run with a real model plus research-capable MCP "
+                "servers so the coach can ground critiques in current sources."
+            ),
+            "",
+            "## Follow-up work",
+            "",
+            "1. Supply a `fastagent.config.yaml` that defines the search/fetch MCP servers used by the coach.",
+            "2. Retry the live run with Malachi if credentials or a supported model binding become available.",
+            "3. Save one real transcript from the live run and compare the resulting spec quality against the existing loop state approach.",
+            "",
+            "## Reference links",
+            "",
+            "- fast-agent docs: https://fast-agent.ai/",
+            "- fast-agent workflow docs: https://fast-agent.ai/agents/workflows/",
+            "- fast-agent model docs: https://fast-agent.ai/models/",
+            "- fast-agent package: https://pypi.org/project/fast-agent-mcp/",
+            "",
+        ]
+    )
+
+
+def _stringify_fast_agent_result(result: object) -> str:
+    if isinstance(result, str):
+        return result
+
+    first_text = getattr(result, "first_text", None)
+    if callable(first_text):
+        text = first_text()
+        if isinstance(text, str):
+            return text
+
+    text = getattr(result, "text", None)
+    if isinstance(text, str):
+        return text
+
+    return str(result)
+
+
+async def _run_live_experiment(
+    topic: str,
+    output_path: Path,
+    config_path: str,
+    model: str,
+    loop: LoopConfig,
+) -> str:
+    try:
+        from mcp_agent.core.fastagent import FastAgent
+    except ImportError as exc:
+        raise RuntimeError(
+            "fast-agent-mcp is not installed. Install it with `pip install -e '.[fast-agent]'` first."
+        ) from exc
+
+    fast = FastAgent(
+        "But Dad fast-agent experiment",
+        config_path=config_path,
+        parse_cli_args=False,
+        quiet=True,
+    )
+
+    @fast.agent(
+        name="Writer",
+        model=model,
+        instruction=build_writer_instruction(loop),
+        use_history=True,
+    )
+    @fast.agent(
+        name="Coach",
+        model=model,
+        instruction=build_coach_instruction(loop),
+        servers=["brave", "fetch"],
+        use_history=True,
+    )
+    @fast.evaluator_optimizer(
+        name="SpecLoop",
+        generator="Writer",
+        evaluator="Coach",
+        min_rating="EXCELLENT",
+        max_refinements=max(loop.max_writer_turns - 1, 0),
+        instruction=(
+            "Revise the same living spec to address every blocking issue, preserve valid content, "
+            "and improve acceptance criteria, edge cases, and source appendix quality."
+        ),
+    )
+    async def run() -> str:
+        async with fast.run() as agent:
+            result = await agent.SpecLoop.send(build_loop_prompt(topic, loop))
+            rendered = _stringify_fast_agent_result(result)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(rendered)
+            return rendered
+
+    return await run()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the But Dad fast-agent experiment.")
+    parser.add_argument("--topic", default=DEFAULT_TOPIC)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT_PATH)
+    parser.add_argument("--findings", type=Path, default=DEFAULT_FINDINGS_PATH)
+    parser.add_argument("--config-path", default=DEFAULT_CONFIG_PATH)
+    parser.add_argument("--model", default=DEFAULT_LIVE_MODEL)
+    parser.add_argument("--live", action="store_true")
+    args = parser.parse_args(argv)
+
+    loop = LoopConfig()
+    malachi_check = detect_malachi_support()
+    output_text = build_dry_run_transcript(args.topic, loop)
+
+    if args.live:
+        output_text = asyncio.run(
+            _run_live_experiment(args.topic, args.output, args.config_path, args.model, loop)
+        )
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output_text)
+
+    args.findings.parent.mkdir(parents=True, exist_ok=True)
+    args.findings.write_text(build_findings_markdown(args.topic, malachi_check, loop))
+    print(f"Wrote output to {args.output}")
+    print(f"Wrote findings to {args.findings}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fast_agent_experiment.py
+++ b/tests/test_fast_agent_experiment.py
@@ -1,0 +1,54 @@
+from but_dad.fast_agent_experiment import (
+    build_coach_instruction,
+    build_dry_run_transcript,
+    build_findings_markdown,
+    build_live_command,
+    build_loop_prompt,
+    detect_malachi_support,
+)
+
+
+def test_dry_run_transcript_uses_six_turn_budget() -> None:
+    transcript = build_dry_run_transcript("Draft an issue handoff spec")
+
+    assert transcript.count("## Writer turn") == 6
+    assert transcript.count("## Coach turn") == 6
+    assert "deterministic preview" in transcript
+
+
+def test_loop_prompt_mentions_web_research_and_final_artifact() -> None:
+    prompt = build_loop_prompt("Design a spec loop")
+    coach = build_coach_instruction()
+
+    assert "web research" in prompt.lower()
+    assert "source appendix" in prompt.lower()
+    assert "Overall rating" in coach
+    assert "Sources consulted" in coach
+
+
+def test_malachi_check_reports_missing_environment_signal() -> None:
+    check = detect_malachi_support(env_var_names=("OPENAI_API_KEY", "BRAVE_API_KEY"))
+
+    assert check.available is False
+    assert "No MALACHI-related environment variables" in check.summary
+    assert len(check.evidence) == 2
+
+
+def test_findings_include_commands_and_verdict() -> None:
+    findings = build_findings_markdown(
+        "Design a writer-versus-coach loop",
+        detect_malachi_support(env_var_names=()),
+    )
+
+    assert "python -m but_dad.fast_agent_experiment" in findings
+    assert "--live --config-path" in findings
+    assert "good structural fit" in findings.lower()
+    assert "Follow-up work" in findings
+
+
+def test_live_command_contains_placeholder_config_and_model() -> None:
+    command = build_live_command("Ship the spec loop")
+
+    assert "--live" in command
+    assert "--config-path path/to/fastagent.config.yaml" in command
+    assert "--model sonnet" in command


### PR DESCRIPTION
## Summary
- add a minimal `fast-agent` writer/coach experiment for But Dad's spec loop
- save a deterministic dry-run transcript plus written findings under `docs/experiments/`
- document the runnable command, fast-agent fit assessment, and the precise local blocker for verifying Malachi live

## Verification
- `.venv/bin/pytest -q`
- `.venv/bin/python -m but_dad.fast_agent_experiment --topic 'Test topic' --output /tmp/but-dad-dry-run.md --findings /tmp/but-dad-findings.md`

Closes #8.
